### PR TITLE
Not trialing

### DIFF
--- a/app/assets/javascripts/companies.js
+++ b/app/assets/javascripts/companies.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/companies.scss
+++ b/app/assets/stylesheets/companies.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Companies controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,2 @@
+class CompaniesController < ApplicationController
+end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -4,4 +4,9 @@ class CompaniesController < ApplicationController
     render json: {data: Company.all}
   end
 
+  def alphabetically
+    @companies = Company.all.order(name:"ASC")
+    render json: {data: @companies}
+  end
+
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,17 +1,37 @@
 class CompaniesController < ApplicationController
 
+  # Get the companies list, except when we're modifying a single record
+  before_action :set_companies_list, except: [:edit, :show, :update, :destroy]
+
   def index
-    render json: {data: Company.all}
+    # Get a list of all companies
+    render json: {data: @companies}
   end
 
   def alphabetically
-    @companies = Company.all.order(name:"ASC")
-    render json: {data: @companies}
+    # Render Company names sorted Alphabetically
+    render json: {data: @companies.order(name:"ASC")
+    }
   end
 
   def with_modern_plan
-    @companies = Company.all.where(plan_level_id: [3,4,5,6]).order(name: "ASC")
-    render json: {data: @companies}
+    # Render companies with a modern plan
+    # AKA Plan Level ID is not 1 or 2
+    render json: {data: @companies.where(plan_level_id: [3,4,5,6])
+                        .order(name: "ASC")}
+  end
+
+  def not_trialing
+    # Render only companies without active trials
+    # AKA trial_status == nil
+    render json: {data: @companies.where(trial_status: nil)}
+  end
+
+  private
+
+  def set_companies_list
+    # Get this once so we don't have to keep getting it
+    @companies = Company.all
   end
 
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,2 +1,7 @@
 class CompaniesController < ApplicationController
+
+  def index
+    render json: {data: Company.all}
+  end
+
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -9,4 +9,9 @@ class CompaniesController < ApplicationController
     render json: {data: @companies}
   end
 
+  def with_modern_plan
+    @companies = Company.all.where(plan_level_id: [3,4,5,6]).order(name: "ASC")
+    render json: {data: @companies}
+  end
+
 end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -1,0 +1,2 @@
+module CompaniesHelper
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,6 @@
 class Company < ApplicationRecord
   belongs_to :plan_level
+  has_many :lessons
 
   validates :name, :trial_status, :plan_level, presence: true
   validates :name, length: {minimum: 2, maximum: 254}

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,8 @@
 class Company < ApplicationRecord
   belongs_to :plan_level
+
   has_many :lessons
 
-  validates :name, :trial_status, :plan_level, presence: true
+  validates :name, presence: true
   validates :name, length: {minimum: 2, maximum: 254}
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,0 +1,6 @@
+class Company < ApplicationRecord
+  belongs_to :plan_level
+
+  validates :name, :trial_status, :plan_level, presence: true
+  validates :name, length: {minimum: 2, maximum: 254}
+end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,6 +1,6 @@
 class Lesson < ApplicationRecord
   belongs_to :company
 
-  validates :name, presence: true
-  validates_format_of :name, format: { with: /([a-z0-9])/i }
+  validates :name, format: { with: /([a-z0-9])/i,
+    message: 'Letters and numbers only' }
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,6 @@
+class Lesson < ApplicationRecord
+  belongs_to :company
+
+  validates :name, presence: true
+  validates_format_of :name, format: { with: /([a-z0-9])/i }
+end

--- a/app/models/plan_level.rb
+++ b/app/models/plan_level.rb
@@ -1,0 +1,2 @@
+class PlanLevel < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  resources :companies
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'companies/alphabetically', to: 'companies#alphabetically'
+
   resources :companies
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get 'companies/alphabetically', to: 'companies#alphabetically'
   get 'companies/with_modern_plan', to: 'companies#with_modern_plan'
+  get 'companies/not_trialing', to: 'companies#not_trialing'
+
   resources :companies
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'companies/alphabetically', to: 'companies#alphabetically'
-
+  get 'companies/with_modern_plan', to: 'companies#with_modern_plan'
   resources :companies
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20171128154437_create_lessons.rb
+++ b/db/migrate/20171128154437_create_lessons.rb
@@ -1,0 +1,11 @@
+class CreateLessons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lessons do |t|
+      t.string :name
+      t.references :company, foreign_key: true
+      t.boolean :active
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171128142230) do
+ActiveRecord::Schema.define(version: 20171128154437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 20171128142230) do
     t.index ["plan_levels_id"], name: "index_companies_on_plan_levels_id"
   end
 
+  create_table "lessons", force: :cascade do |t|
+    t.string "name"
+    t.bigint "company_id"
+    t.boolean "active"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_lessons_on_company_id"
+  end
+
   create_table "plan_levels", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -31,4 +40,5 @@ ActiveRecord::Schema.define(version: 20171128142230) do
   end
 
   add_foreign_key "companies", "plan_levels", column: "plan_levels_id"
+  add_foreign_key "lessons", "companies"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,10 +18,10 @@ ActiveRecord::Schema.define(version: 20171128154437) do
   create_table "companies", force: :cascade do |t|
     t.string "name"
     t.date "trial_status"
-    t.bigint "plan_levels_id"
+    t.bigint "plan_level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["plan_levels_id"], name: "index_companies_on_plan_levels_id"
+    t.index ["plan_level_id"], name: "index_companies_on_plan_level_id"
   end
 
   create_table "lessons", force: :cascade do |t|
@@ -39,6 +39,6 @@ ActiveRecord::Schema.define(version: 20171128154437) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "companies", "plan_levels", column: "plan_levels_id"
+  add_foreign_key "companies", "plan_levels", column: "plan_level_id"
   add_foreign_key "lessons", "companies"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,34 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20171128142230) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "companies", force: :cascade do |t|
+    t.string "name"
+    t.date "trial_status"
+    t.bigint "plan_levels_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_levels_id"], name: "index_companies_on_plan_levels_id"
+  end
+
+  create_table "plan_levels", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "companies", "plan_levels", column: "plan_levels_id"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Dir[File.join(Rails.root, 'db', 'seeds', '*.rb')].sort.each { |seed| load seed }

--- a/db/seeds/01_plan_levels.rb
+++ b/db/seeds/01_plan_levels.rb
@@ -1,4 +1,6 @@
-  PlanLevel.create!(
+planlevel = PlanLevel.all
+if planlevel.length.nil? || planlevel.length < 6
+  PlanLevel.create(
     [
       { name: 'Legacy' },
       { name: 'Custom' },
@@ -8,3 +10,4 @@
       { name: 'Enterprise' }
     ]
   )
+end

--- a/db/seeds/01_plan_levels.rb
+++ b/db/seeds/01_plan_levels.rb
@@ -1,0 +1,10 @@
+  PlanLevel.create!(
+    [
+      { name: 'Legacy' },
+      { name: 'Custom' },
+      { name: 'Basic' },
+      { name: 'Plus' },
+      { name: 'Growth' },
+      { name: 'Enterprise' }
+    ]
+  )

--- a/db/seeds/02_companies.rb
+++ b/db/seeds/02_companies.rb
@@ -1,20 +1,25 @@
-Company.create!(
-  [
-    { name: 'Lord Elrond\'s Glorious Cupcakes',
-      trial_status: (Date.today + 10),
-      plan_level_id: PlanLevel.find(1).id },
-    { name: 'Things are Getting Dicey',
-      trial_status: (Date.today + 15),
-      plan_level_id: PlanLevel.find(3).id },
-    { name: 'The Future is Bright',
-      trial_status: (Date.today + 20),
-      plan_level_id: PlanLevel.find(6).id },
-    { name: 'Lox and Roll Deli',
-      trial_status: (Date.today + 25),
-      plan_level_id: PlanLevel.find(4).id }
-  ]
-)
-
+companies = Company.all
+if companies.length < 5
+  Company.create!(
+    [
+      { name: 'Lord Elrond\'s Glorious Cupcakes',
+        trial_status: (Date.today + 10),
+        plan_level_id: PlanLevel.find(1).id },
+      { name: 'Things are Getting Dicey',
+        trial_status: (Date.today + 15),
+        plan_level_id: PlanLevel.find(3).id },
+      { name: 'The Future is Bright',
+        trial_status: (Date.today + 20),
+        plan_level_id: PlanLevel.find(6).id },
+      { name: 'Lox and Roll Deli',
+        trial_status: (Date.today + 25),
+        plan_level_id: PlanLevel.find(4).id },
+      { name: 'AlbaCORE',
+        trial_status: (Date.today + 17),
+        plan_level_id: PlanLevel.find(2).id }
+    ]
+  )
+end
 
 
 

--- a/db/seeds/02_companies.rb
+++ b/db/seeds/02_companies.rb
@@ -15,7 +15,7 @@ if companies.length < 5
         trial_status: (Date.today + 25),
         plan_level_id: PlanLevel.find(4).id },
       { name: 'AlbaCORE',
-        trial_status: (Date.today + 17),
+        # Trial Status intentionally left blank
         plan_level_id: PlanLevel.find(2).id }
     ]
   )

--- a/db/seeds/02_companies.rb
+++ b/db/seeds/02_companies.rb
@@ -1,0 +1,21 @@
+Company.create!(
+  [
+    { name: 'Lord Elrond\'s Glorious Cupcakes',
+      trial_status: (Date.today + 10),
+      plan_level_id: PlanLevel.find(1).id },
+    { name: 'Things are Getting Dicey',
+      trial_status: (Date.today + 15),
+      plan_level_id: PlanLevel.find(3).id },
+    { name: 'The Future is Bright',
+      trial_status: (Date.today + 20),
+      plan_level_id: PlanLevel.find(6).id },
+    { name: 'Lox and Roll Deli',
+      trial_status: (Date.today + 25),
+      plan_level_id: PlanLevel.find(4).id }
+  ]
+)
+
+
+
+
+

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CompaniesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  trial_status: 2017-11-28
+
+two:
+  name: MyString
+  trial_status: 2017-11-28

--- a/test/fixtures/lessons.yml
+++ b/test/fixtures/lessons.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  company: one
+  active: false
+
+two:
+  name: MyString
+  company: two
+  active: false

--- a/test/fixtures/plan_levels.yml
+++ b/test/fixtures/plan_levels.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  company: one
+
+two:
+  name: MyString
+  company: two

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CompanyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/lesson_test.rb
+++ b/test/models/lesson_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LessonTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/plan_level_test.rb
+++ b/test/models/plan_level_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PlanLevelTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds not_trialing endpoint to companies#not_trialing
Adds Route for not_trialing
Adds comments to Companies Controller
Adds before_action to set Companies object once, except when editing a single object
    Renders the JSON with the required options on the previously received Companies object
Updates AlbaCORE to have a NIL trial_status value